### PR TITLE
[CU-86dwkfvm4] Install Sanctum without depending on the boilerplate

### DIFF
--- a/src/Auth/Installers/SanctumInstaller.php
+++ b/src/Auth/Installers/SanctumInstaller.php
@@ -25,6 +25,8 @@ final class SanctumInstaller implements AuthInstallerInterface
     {
         $this->command->info('Installing Sanctum-API Token Authentication...');
 
+        $this->command->call('install:api');
+        
         $this->createAuthFiles();
 
         $this->command->info('Sanctum-API Token Authentication installed successfully!');


### PR DESCRIPTION
# ⚡ Install Sanctum without depending on the boilerplate - [CU-86dwkfvm4](https://app.clickup.com/t/86dwkfvm4) ⚡

## 💻 What type of change is this?

- [x] 💎 Feature

## ⭐ Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
Example:
-->


<!--
ONLY ADD SECTION IF A NEW PACKAGE IS ADDED
### Requires
This pr requires the following packages to be installed:
- `package1`
- `package2`
The packages are used for `reason1` and `reason2`.

Because of this, you must run `npm i` before starting.
-->

## 📷 Screenshots

## Before

https://github.com/user-attachments/assets/12e41f15-1ce2-4a0a-bffc-ae0e384ef40f

## After

https://github.com/user-attachments/assets/4fdfa783-549f-455d-a33e-a2300a873df5




## ✅ Checklist
### To review
- [ ] I have tested this change locally in multiple screen sizes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If my task include an endpoint, I add the endpoint to Hopscotch/Postman Project
- [ ] Any dependent changes have been merged and published in downstream modules