### PR TITLE
[no-task] Laravel 13 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     ],
     "require": {
         "php": "^8.4",
-        "illuminate/contracts": "^11.0||^12.0",
+        "illuminate/contracts": "^11.0||^12.0||^13.0",
         "php-open-source-saver/jwt-auth": "^2.0",
         "spatie/laravel-package-tools": "^1.16"
     },


### PR DESCRIPTION
# ⚡ Laravel 13 Compatibility ⚡

## 💻 What type of change is this?

- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [x] Chore / dependency update

## ⭐ Description

Extends the `illuminate/contracts` version constraint in `composer.json` to include `^13.0`, allowing this package to be installed alongside Laravel 13. No code changes were required — the existing implementation is already compatible.

**Change:**
```
"illuminate/contracts": "^11.0||^12.0"  →  "illuminate/contracts": "^11.0||^12.0||^13.0"
```

## 💬 Comments

No breaking changes. Laravel 11 and 12 consumers are unaffected.

## ✅ Checklist
### To review
- [ ] I have tested this change locally in multiple screen sizes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If my task include an endpoint, I add the endpoint to Hopscotch/Postman Project
- [x] Any dependent changes have been merged and published in downstream modules
