### PR TITLE
[no-task] Update GitHub Actions Dependencies

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main
 


### PR DESCRIPTION
# ⚡ Update GitHub Actions Dependencies ⚡

## 💻 What type of change is this?

- [ ] Bug fix
- [ ] New feature
- [x] Chore / Maintenance
- [ ] Breaking change
- [ ] This change requires a documentation update

## ⭐ Description

Bumps GitHub Actions dependencies to their latest versions:

- `actions/checkout`: `v5` → `v6` (used in `phpstan.yml`, `run-tests.yml`, `update-changelog.yml`)
- `dependabot/fetch-metadata`: `v2.4.0` → `v2.5.0` (used in `dependabot-auto-merge.yml`)

## ✅ Checklist
### To review
- [ ] I have tested this change locally in multiple screen sizes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If my task include an endpoint, I add the endpoint to Hopscotch/Postman Project
- [x] Any dependent changes have been merged and published in downstream modules
