### PR TITLE
Update Exceptions to Match Boilerplate

### DIFF
--- a/src/Stubs/Google2FA/Auth/Actions/PasswordValidatorAction.stub
+++ b/src/Stubs/Google2FA/Auth/Actions/PasswordValidatorAction.stub
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Lightit\Authentication\Domain\Actions;
 
 use Illuminate\Support\Facades\Hash;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 use Lightit\Users\Domain\Models\User;
 
 final readonly class PasswordValidatorAction
 {
     /**
-     * @throws UnauthorizedException
+     * @throws UnauthenticatedException
      */
     public function execute(User $user, string $password): void
     {
         if (! Hash::check($password, $user->getAuthPassword())) {
-            throw new UnauthorizedException(__('errors.invalid_password'));
+            throw new UnauthenticatedException(__('errors.invalid_password'));
         }
     }
 }

--- a/src/Stubs/Google2FA/Auth/Actions/Pipes/ValidateCredentials.stub
+++ b/src/Stubs/Google2FA/Auth/Actions/Pipes/ValidateCredentials.stub
@@ -6,18 +6,18 @@ namespace Lightit\Authentication\Domain\Actions\Pipes;
 
 use Closure;
 use Illuminate\Contracts\Auth\StatefulGuard;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 
 final readonly class ValidateCredentials
 {
-    /** @throws UnauthorizedException */
+    /** @throws UnauthenticatedException */
     public function handle(LoginContext $context, Closure $next): mixed
     {
         /** @var StatefulGuard $guard */
         $guard = $context->guard;
 
         if (! $guard->attempt($context->credentials->toArray())) {
-            throw new UnauthorizedException(message: __('google2fa.invalid_credentials'));
+            throw new UnauthenticatedException(message: __('google2fa.invalid_credentials'));
         }
 
         return $next($context);

--- a/src/Stubs/Google2FA/JWT/Auth/Actions/CompleteTwoFactorAuthenticationAction.stub
+++ b/src/Stubs/Google2FA/JWT/Auth/Actions/CompleteTwoFactorAuthenticationAction.stub
@@ -7,7 +7,7 @@ namespace Lightit\Authentication\Domain\Actions;
 use Illuminate\Support\Facades\Config;
 use Lightit\Authentication\Domain\DataTransferObjects\LoginDto;
 use Lightit\Authentication\Domain\TwoFactorAuthenticatable;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 use PHPOpenSourceSaver\JWTAuth\JWTAuth;
 
 final readonly class CompleteTwoFactorAuthenticationAction
@@ -23,7 +23,7 @@ final readonly class CompleteTwoFactorAuthenticationAction
         $secret = $user->getTwoFactorAuthSecret();
 
         if (is_null($secret)) {
-            throw new UnauthorizedException(__('google2fa.secret_not_configured'));
+            throw new UnauthenticatedException(__('google2fa.secret_not_configured'));
         }
 
         $this->verifyOtpAction->execute($secret, $oneTimePassword);

--- a/src/Stubs/Google2FA/JWT/Auth/Actions/VerifyRecoveryCodeAction.stub
+++ b/src/Stubs/Google2FA/JWT/Auth/Actions/VerifyRecoveryCodeAction.stub
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
 use Lightit\Authentication\Domain\DataTransferObjects\LoginDto;
 use Lightit\Authentication\Domain\DataTransferObjects\VerifyRecoveryCodeDto;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 use Lightit\Users\Domain\Models\User;
 use PHPOpenSourceSaver\JWTAuth\JWTGuard;
 
@@ -21,14 +21,14 @@ final readonly class VerifyRecoveryCodeAction
     }
 
     /**
-     * @throws UnauthorizedException
+     * @throws UnauthenticatedException
      */
     public function execute(User $user, string $suppliedCode): VerifyRecoveryCodeDto
     {
         $hashedCodes = $user->getRecoveryCodes();
 
         if ($hashedCodes === []) {
-            throw new UnauthorizedException(__('google2fa.invalid_recovery_code'));
+            throw new UnauthenticatedException(__('google2fa.invalid_recovery_code'));
         }
 
         $matchIndex = -1;
@@ -42,7 +42,7 @@ final readonly class VerifyRecoveryCodeAction
         }
 
         if ($matchIndex === -1) {
-            throw new UnauthorizedException(__('google2fa.invalid_recovery_code'));
+            throw new UnauthenticatedException(__('google2fa.invalid_recovery_code'));
         }
 
         unset($hashedCodes[$matchIndex]);

--- a/src/Stubs/Google2FA/Sanctum/Auth/Actions/CompleteTwoFactorAuthenticationAction.stub
+++ b/src/Stubs/Google2FA/Sanctum/Auth/Actions/CompleteTwoFactorAuthenticationAction.stub
@@ -7,7 +7,7 @@ namespace Lightit\Authentication\Domain\Actions;
 use Illuminate\Support\Facades\Config;
 use Lightit\Authentication\Domain\DataTransferObjects\LoginDto;
 use Lightit\Authentication\Domain\TwoFactorAuthenticatable;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 use Lightit\Users\Domain\Models\User;
 
 final readonly class CompleteTwoFactorAuthenticationAction
@@ -22,7 +22,7 @@ final readonly class CompleteTwoFactorAuthenticationAction
         $secret = $user->getTwoFactorAuthSecret();
 
         if (is_null($secret)) {
-            throw new UnauthorizedException(__('google2fa.secret_not_configured'));
+            throw new UnauthenticatedException(__('google2fa.secret_not_configured'));
         }
 
         $this->verifyOtpAction->execute($secret, $oneTimePassword);

--- a/src/Stubs/Google2FA/Sanctum/Auth/Actions/VerifyRecoveryCodeAction.stub
+++ b/src/Stubs/Google2FA/Sanctum/Auth/Actions/VerifyRecoveryCodeAction.stub
@@ -8,20 +8,20 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
 use Lightit\Authentication\Domain\DataTransferObjects\LoginDto;
 use Lightit\Authentication\Domain\DataTransferObjects\VerifyRecoveryCodeDto;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 use Lightit\Users\Domain\Models\User;
 
 final readonly class VerifyRecoveryCodeAction
 {
     /**
-     * @throws UnauthorizedException
+     * @throws UnauthenticatedException
      */
     public function execute(User $user, string $suppliedCode): VerifyRecoveryCodeDto
     {
         $hashedCodes = $user->getRecoveryCodes();
 
         if ($hashedCodes === []) {
-            throw new UnauthorizedException(__('google2fa.invalid_recovery_code'));
+            throw new UnauthenticatedException(__('google2fa.invalid_recovery_code'));
         }
 
         $matchIndex = -1;
@@ -35,7 +35,7 @@ final readonly class VerifyRecoveryCodeAction
         }
 
         if ($matchIndex === -1) {
-            throw new UnauthorizedException(__('google2fa.invalid_recovery_code'));
+            throw new UnauthenticatedException(__('google2fa.invalid_recovery_code'));
         }
 
         unset($hashedCodes[$matchIndex]);

--- a/src/Stubs/Sanctum/Auth/Actions/LoginAction.stub
+++ b/src/Stubs/Sanctum/Auth/Actions/LoginAction.stub
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Support\Facades\Config;
 use Lightit\Authentication\Domain\DataTransferObjects\CredentialsDto;
 use Lightit\Authentication\Domain\DataTransferObjects\LoginDto;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 use Lightit\Users\Domain\Models\User;
 
 final class LoginAction
@@ -19,14 +19,14 @@ final class LoginAction
     }
 
     /**
-     * @throws UnauthorizedException
+     * @throws UnauthenticatedException
      */
     public function execute(CredentialsDto $credentials): LoginDto
     {
         $guard = $this->factory->guard();
 
         if (! $guard->attempt($credentials->toArray())) {
-            throw new UnauthorizedException();
+            throw new UnauthenticatedException();
         }
 
         /** @var User $user */

--- a/src/Stubs/jwt/Auth/Actions/LoginAction.stub
+++ b/src/Stubs/jwt/Auth/Actions/LoginAction.stub
@@ -7,7 +7,7 @@ namespace Lightit\Authentication\Domain\Actions;
 use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Lightit\Authentication\Domain\DataTransferObjects\CredentialsDto;
 use Lightit\Authentication\Domain\DataTransferObjects\LoginDto;
-use Lightit\Shared\App\Exceptions\Http\UnauthorizedException;
+use Lightit\Shared\App\Exceptions\Http\UnauthenticatedException;
 use PHPOpenSourceSaver\JWTAuth\Factory as JWTAuth;
 use PHPOpenSourceSaver\JWTAuth\JWTGuard;
 
@@ -20,7 +20,7 @@ final class LoginAction
     }
 
     /**
-     * @throws UnauthorizedException
+     * @throws UnauthenticatedException
      */
     public function execute(CredentialsDto $credentials): LoginDto
     {
@@ -28,7 +28,7 @@ final class LoginAction
         $guard = $this->factory->guard();
 
         if (! $token = $guard->attempt($credentials->toArray())) {
-            throw new UnauthorizedException();
+            throw new UnauthenticatedException();
         }
 
         /** @var string $token */


### PR DESCRIPTION
## Description

The auth stubs shipped by this package import and throw `Lightit\Shared\App\Exceptions\Http\UnauthorizedException` — a class that **does not exist** in the [Light-it Laravel boilerplate](https://github.com/Light-it-labs/laravel) this package is designed to scaffold into.

The boilerplate's `src/Shared/App/Exceptions/Http/` directory exposes `UnauthenticatedException` (HTTP 401) instead — there is no `UnauthorizedException`. As a result, **any project that installs auth (JWT, Sanctum or Google2FA) from these stubs fails to compile** with:

```
Class "Lightit\Shared\App\Exceptions\Http\UnauthorizedException" not found
```

This was hit in practice while scaffolding a new project from the boilerplate + this package, and had to be patched by hand.

## Fix

Replace every reference to `UnauthorizedException` with the boilerplate's `UnauthenticatedException` across the 8 affected stubs (import, `@throws`, and `throw new`). `UnauthenticatedException extends HttpException`, whose constructor is `__construct(string|null $message = null, array|null $headers = null)`, so every call site here compiles — including the ones that pass a translated message positionally or via the named `message:` argument.

Semantically correct too: these throws all represent failed authentication (invalid credentials / recovery code / 2FA secret), i.e. HTTP 401, which is exactly what `UnauthenticatedException` models.

### Stubs updated
- `src/Stubs/jwt/Auth/Actions/LoginAction.stub`
- `src/Stubs/Sanctum/Auth/Actions/LoginAction.stub`
- `src/Stubs/Google2FA/Auth/Actions/PasswordValidatorAction.stub`
- `src/Stubs/Google2FA/Auth/Actions/Pipes/ValidateCredentials.stub`
- `src/Stubs/Google2FA/JWT/Auth/Actions/CompleteTwoFactorAuthenticationAction.stub`
- `src/Stubs/Google2FA/JWT/Auth/Actions/VerifyRecoveryCodeAction.stub`
- `src/Stubs/Google2FA/Sanctum/Auth/Actions/CompleteTwoFactorAuthenticationAction.stub`
- `src/Stubs/Google2FA/Sanctum/Auth/Actions/VerifyRecoveryCodeAction.stub`